### PR TITLE
Goreleaser action

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -1,0 +1,28 @@
+name: make-release
+on: [push, pull_request]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker://golangci/golangci-lint:v1.41.1
+        with:
+          args: golangci-lint run
+
+  release:
+    name: Release
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs:
+      - lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: GoReleaser
+        uses: goreleaser/goreleaser-action@v1
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/main.go
+++ b/main.go
@@ -125,6 +125,8 @@ func restart(targetImageName string) error {
 		}
 	}
 
+	log.Printf("[!] Stopped %d containers", len(stoppedContainers))
+
 	log.Printf("[>] pulling %s ...\n", targetImageName)
 
 	// pull new version of image


### PR DESCRIPTION
Return the release building action back. Now it can add releases after tagging a commit